### PR TITLE
fix(market): index seller event filter new smart offer

### DIFF
--- a/contracts/marketplace/Market.sol
+++ b/contracts/marketplace/Market.sol
@@ -18,7 +18,7 @@ contract Market {
 	mapping(uint256 => SmartOffer) smartOffers;
 
 	event NewSmartOffer(
-		address seller,
+		address indexed seller,
 		uint256 what,
 		uint256 price,
 		address money,


### PR DESCRIPTION
NewSmartOffer event needs to have indexed seller in order to filter events by user. Perhaps other properties should also be indexed? I'm not certain.