### PR TITLE
`Pausable` bypass for creator's transfers & integration with `InstantOffer`

### DIFF
--- a/contracts/assets/cargo/PausableCargo.sol
+++ b/contracts/assets/cargo/PausableCargo.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.9;
 
 import '@openzeppelin/contracts/token/ERC1155/ERC1155.sol';
-
 import '../interfaces/Pausable.sol';
 
 abstract contract PausableCargo is ERC1155, Pausable {
@@ -23,7 +22,7 @@ abstract contract PausableCargo is ERC1155, Pausable {
         uint256[] memory amounts,
         bytes memory data
     ) internal virtual override {
-        require(!paused || from == creator, 'Pausable: only creator can transfer paused assets');
+        require(!paused || from == creator, 'PausableCargo: asset is locked');
         super._beforeTokenTransfer(operator, from, to, ids, amounts, data);
     }
 

--- a/contracts/offers/InstantOffer.sol
+++ b/contracts/offers/InstantOffer.sol
@@ -58,7 +58,7 @@ contract InstantOffer {
         );
 
         address creator = CargoAsset(asset).creator();
-        require(!CargoAsset(asset).paused() || msg.sender == creator, 'Only creator can sell paused asset');
+        require(!CargoAsset(asset).paused() || msg.sender == creator, 'PausableCargo: asset is locked');
 
         sellID = numOffers++;
         Offer storage offer = offers[sellID];

--- a/test/asset/cargo/pausable.test.ts
+++ b/test/asset/cargo/pausable.test.ts
@@ -18,18 +18,18 @@ describe('[test/asset/cargo/pausable.test] SpaceCargo asset: pausable test suite
 		await expect(cargoContract.connect(receiver).pause()).to.be.revertedWith('unauthorized -- only for creator')
 	})
 
-	describe('transfers when asset `paused()`', async() => {
-		before('load userA and transfer funds', async() => {
+	describe('transfers when asset `paused()`', async () => {
+		before('load userA and transfer funds', async () => {
 			// set up a signer who will send the asset
-			[, , userA] = await ethers.getSigners()
+			;[, , userA] = await ethers.getSigners()
 			await cargoContract.connect(creator).transfer(userA.address, 0, '100')
 		})
 
-		before('pause asset', async() => {
+		before('pause asset', async () => {
 			await cargoContract.connect(creator).pause()
 		})
 
-		it('creator can successfully send tokens if paused', async() => {
+		it('creator can successfully send tokens if paused', async () => {
 			const amount = parseUnits('100', 18)
 
 			const balanceStart = await cargoContract.balanceOf(receiver.address, 0)
@@ -38,13 +38,11 @@ describe('[test/asset/cargo/pausable.test] SpaceCargo asset: pausable test suite
 
 			expect(balanceStart.add(BigNumber.from(amount))).to.be.eq(balanceEnd)
 		})
-	
+
 		it('non-creator cannot send tokens if paused', async () => {
 			await expect(
 				cargoContract.connect(userA).transfer(receiver.address, 0, parseUnits('100', 18))
-			).to.be.revertedWith('Pausable: only creator can transfer paused assets')
+			).to.be.revertedWith('PausableCargo: asset is locked')
 		})
 	})
-
-	
 })

--- a/test/offers/instant/offer-paused.test.ts
+++ b/test/offers/instant/offer-paused.test.ts
@@ -9,7 +9,7 @@ import { TX_RECEIPT_STATUS } from '../../../constants/tx-receipt-status'
 import { getOfferSellID } from '../../helpers/getOfferId.helper'
 import { deployInstantOffer } from './fixtures/deployOffer.fixture'
 
-describe('[test/offers/instant/offer.test] Instant offer: deployOffer fixture test suite', () => {
+describe('[test/offers/instant/offer-paused.test] Instant offer: deployOffer fixture test suite', () => {
 	let deployer: SignerWithAddress
 	let creator: SignerWithAddress
 	let instantOffer: InstantOffer
@@ -67,7 +67,7 @@ describe('[test/offers/instant/offer.test] Instant offer: deployOffer fixture te
 		it('reverts create offer from non-creator', async () => {
 			await expect(
 				instantOffer.connect(userA).sell(cargoContract.address, 0, '100', price, erc20Mock.address)
-			).to.be.revertedWith('Only creator can sell paused asset')
+			).to.be.revertedWith('PausableCargo: asset is locked')
 		})
 
 		it('successfully creates offer if `msg.sender == creator`', async () => {
@@ -89,7 +89,7 @@ describe('[test/offers/instant/offer.test] Instant offer: deployOffer fixture te
 			const approveAmount = price.mul(buyAmountDecimal)
 			await erc20Mock.connect(userA).approve(instantOffer.address, approveAmount)
 		})
-        
+
 		it('allows userA to buy asset', async () => {
 			await instantOffer.connect(userA).buy(0, '100')
 			expect(await cargoContract.balanceOf(userA.address, '0')).to.be.eq(
@@ -100,7 +100,7 @@ describe('[test/offers/instant/offer.test] Instant offer: deployOffer fixture te
 		it('disallows resell from non-creator', async () => {
 			await expect(
 				instantOffer.connect(userA).sell(cargoContract.address, 0, '100', '5000', erc20Mock.address)
-			).to.be.revertedWith('Only creator can sell paused asset')
+			).to.be.revertedWith('PausableCargo: asset is locked')
 		})
 	})
 


### PR DESCRIPTION
changes to the `_beforeTokenTransfer` hook to allow creators to transfer assets even when paused