### PR TITLE
Increased `edit.test.ts` asset's balance

### DIFF
--- a/test/spaceibles/offer/edit.test.ts
+++ b/test/spaceibles/offer/edit.test.ts
@@ -49,7 +49,7 @@ describe('[spaceibles/offer/edit]', () => {
 	const asset = {
 		id: undefined,
 		cid: 'mockCID-deployer-0x123abc',
-		balance: 142,
+		balance: 200,
 		royalties: 0,
 		data: '0x'
 	}


### PR DESCRIPTION
Minor change to increase asset balance (`142` --> `200`)

Asset balance must be at least 200, since the offer is edited to have 200 balance in testing later on